### PR TITLE
Updating swagger definitions

### DIFF
--- a/curate-api/query.api.yml
+++ b/curate-api/query.api.yml
@@ -60,12 +60,24 @@ paths:
           schema:
             type: file
           headers:
+            Accepts-Ranges:
+              type: string
+              description: Indicates support of range requests; 'bytes'
+            Content-Length:
+              type: integer
+              description: Size of the content in bytes
             Content-Type:
               type: string
-              description: application/pdf
+              description: MIME Type of the content e.g. 'application/pdf
             Content-Disposition:
               type: string
-              description: inline; filename=example.pdf
+              description: Rendering and handling instcutions e.g. 'inline; filename=example.pdf'
+            ETag:
+              type: integer
+              description: Strong ETag generated for the content
+            Checksum-SHA256:
+              type: string
+              description: Base16 hash for the entire file; not included in range requests; not computed, passed along from underlying metadata
         404: # Could this be 422 for non-file objects?
           description: A non-file object or non-existent object was requested.
           schema:
@@ -85,16 +97,32 @@ paths:
           type: string
       responses:
         200:
-          description: Return the thumbnail
+          description: Return the thumbnail for the given object
           schema:
             type: file
           headers:
+            Accepts-Ranges:
+              type: string
+              description: Indicates support of range requests; 'bytes'
+            Content-Length:
+              type: integer
+              description: Size of the content in bytes
             Content-Type:
               type: string
-              description: image/jpeg
+              description: MIME Type of the content e.g. 'image/jpeg
             Content-Disposition:
               type: string
-              description: inline
+              description: Rendering and handling instcutions e.g. 'inline; filename=thumbnail.jpeg'
+            ETag:
+              type: integer
+              description: Strong ETag generated for the content
+            Checksum-SHA256:
+              type: string
+              description: Base16 hash for the entire file; not included in range requests; not computed, passed along from underlying metadata
+        404:
+          description: A non-existent thumbnail was requested.
+          schema:
+            $ref: '#/definitions/Error'
   /objects:
     get:
       security:

--- a/curate-api/query.api.yml
+++ b/curate-api/query.api.yml
@@ -42,18 +42,18 @@ paths:
           schema:
             $ref: '#/definitions/ObjectInfo'
   /object/{id}/content:
+    parameters:
+    - name: id
+      in: path
+      required: true
+      description: The opaque identifier (e.g Noid) of the object to retrieve
+      type: string
     get:
       security:
         - api_key: []
       tags:
         - Binary Files
       summary: This endpoint is used to retrieve the contents of a `file` object. Calling it on non-file objects will return a 404 error. The unversioned path will return the most current version.
-      parameters:
-        - name: id
-          in: path
-          required: true
-          description: The opaque identifier (e.g Noid) of the object to retrieve
-          type: string
       responses:
         200:
           description: Retrieve the binary contents of the given file.
@@ -82,19 +82,51 @@ paths:
           description: A non-file object or non-existent object was requested.
           schema:
             $ref: '#/definitions/Error'
+    head:
+      summary: Return file metadata without the file payload
+      tags:
+        - Binary Files
+      responses:
+        200:
+          description: Success. Just look at those headers!
+          schema:
+            type: object
+          headers:
+            Accepts-Ranges:
+              type: string
+              description: Indicates support of range requests; 'bytes'
+            Content-Length:
+              type: integer
+              description: Size of the content in bytes
+            Content-Type:
+              type: string
+              description: MIME Type of the content e.g. 'application/pdf
+            Content-Disposition:
+              type: string
+              description: Rendering and handling instcutions e.g. 'inline; filename=example.pdf'
+            ETag:
+              type: integer
+              description: Strong ETag generated for the content
+            Checksum-SHA256:
+              type: string
+              description: Base16 hash for the entire file; not included in range requests; not computed, passed along from underlying metadata
+        404:
+          description: A non-file object or non-existent object was requested.
+          schema:
+            $ref: '#/definitions/Error'
   /objects/{id}/thumbnail:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: The opaque identifier (e.g Noid) of the object to retrieve
+        type: string
     get:
       security:
         - api_key: []
       tags:
         - Binary Files
       summary: Returns the thumbnail image for a collection, work, or file. For a work the thumbnail returned is that of the work’s representative image.
-      parameters:
-        - name: id
-          in: path
-          required: true
-          description: The opaque identifier (e.g Noid) of the object to retrieve
-          type: string
       responses:
         200:
           description: Return the thumbnail for the given object
@@ -119,6 +151,38 @@ paths:
             Checksum-SHA256:
               type: string
               description: Base16 hash for the entire file; not included in range requests; not computed, passed along from underlying metadata
+        404:
+          description: A non-existent thumbnail was requested.
+          schema:
+            $ref: '#/definitions/Error'
+    head:
+      summary: Return thumbnail metadata without the file payload
+      tags:
+        - Binary Files
+      responses:
+        200:
+          description: Success. Just look at those headers!
+          schema:
+            type: object
+          headers:
+            Accepts-Ranges:
+              type: string
+              description: Indicates support of range requests; 'bytes'
+            Content-Length:
+              type: integer
+              description: Size of the content in bytes
+            Content-Type:
+              type: string
+              description: MIME Type of the content e.g. 'image/jpeg
+            Content-Disposition:
+              type: string
+              description: Rendering and handling instcutions e.g. 'inline; filename=thumbnail.jpeg'
+            ETag:
+              type: integer
+              description: Strong ETag generated for the content
+            Checksum-SHA256:
+              type: string
+              description: Base16 hash for the entire file; not computed, passed along from underlying metadata
         404:
           description: A non-existent thumbnail was requested.
           schema:

--- a/curate-api/query.api.yml
+++ b/curate-api/query.api.yml
@@ -68,7 +68,7 @@ paths:
               description: Size of the content in bytes
             Content-Type:
               type: string
-              description: MIME Type of the content e.g. 'application/pdf
+              description: MIME Type of the content e.g. 'application/pdf'
             Content-Disposition:
               type: string
               description: Rendering and handling instcutions e.g. 'inline; filename=example.pdf'
@@ -102,7 +102,7 @@ paths:
               description: Size of the content in bytes
             Content-Type:
               type: string
-              description: MIME Type of the content e.g. 'application/pdf
+              description: MIME Type of the content e.g. 'application/pdf'
             Content-Disposition:
               type: string
               description: Rendering and handling instcutions e.g. 'inline; filename=example.pdf'
@@ -143,7 +143,7 @@ paths:
               description: Size of the content in bytes
             Content-Type:
               type: string
-              description: MIME Type of the content e.g. 'image/jpeg
+              description: MIME Type of the content e.g. 'image/jpeg'
             Content-Disposition:
               type: string
               description: Rendering and handling instcutions e.g. 'inline; filename=thumbnail.jpeg'
@@ -177,7 +177,7 @@ paths:
               description: Size of the content in bytes
             Content-Type:
               type: string
-              description: MIME Type of the content e.g. 'image/jpeg
+              description: MIME Type of the content e.g. 'image/jpeg'
             Content-Disposition:
               type: string
               description: Rendering and handling instcutions e.g. 'inline; filename=thumbnail.jpeg'

--- a/curate-api/query.api.yml
+++ b/curate-api/query.api.yml
@@ -83,9 +83,11 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     head:
-      summary: Return file metadata without the file payload
+      security:
+        - api_key: []
       tags:
         - Binary Files
+      summary: Return file metadata without the file payload
       responses:
         200:
           description: Success. Just look at those headers!
@@ -156,9 +158,11 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     head:
-      summary: Return thumbnail metadata without the file payload
+      security:
+        - api_key: []
       tags:
         - Binary Files
+      summary: Return thumbnail metadata without the file payload
       responses:
         200:
           description: Success. Just look at those headers!

--- a/curate-api/query.api.yml
+++ b/curate-api/query.api.yml
@@ -79,10 +79,16 @@ paths:
           type: string
       responses:
         200:
-          description: Retrieved binary contents of the thumbnail
+          description: Return the thumbnail
           schema:
-            type: string
-            format: binary
+            type: file
+          headers:
+            Content-Type:
+              type: string
+              description: image/jpeg
+            Content-Disposition:
+              type: string
+              description: inline
   /objects:
     get:
       security:

--- a/curate-api/query.api.yml
+++ b/curate-api/query.api.yml
@@ -25,7 +25,7 @@ securityDefinitions:
     in: header
     description: You can request an API key by contacting Don Brower.
 paths:
-  /object/{id}:
+  /objects/{id}:
     get:
       security:
         - api_key: []
@@ -41,7 +41,7 @@ paths:
           description: An ObjectInfo
           schema:
             $ref: '#/definitions/ObjectInfo'
-  /object/{id}/content:
+  /objects/{id}/content:
     parameters:
     - name: id
       in: path

--- a/curate-api/query.api.yml
+++ b/curate-api/query.api.yml
@@ -58,8 +58,14 @@ paths:
         200:
           description: Retrieve the binary contents of the given file.
           schema:
-            type: string
-            format: binary
+            type: file
+          headers:
+            Content-Type:
+              type: string
+              description: application/pdf
+            Content-Disposition:
+              type: string
+              description: inline; filename=example.pdf
         404: # Could this be 422 for non-file objects?
           description: A non-file object or non-existent object was requested.
           schema:

--- a/curate-api/query.api.yml
+++ b/curate-api/query.api.yml
@@ -277,10 +277,10 @@ definitions:
         $ref: '#/definitions/AccessIdentifier'
       date-added:
         type: string
-        format: dateTime
+        format: date-time
       date-modified:
         type: string
-        format: dateTime
+        format: date-time
       filename:
         type: string
       filesize:

--- a/curate-api/query.api.yml
+++ b/curate-api/query.api.yml
@@ -187,23 +187,17 @@ paths:
           description: A non-existent thumbnail was requested.
           schema:
             $ref: '#/definitions/Error'
-  /objects:
+  /search:
     get:
       security:
         - api_key: []
-      summary: Get Objects Info
+      summary: Perform a search and return results. Pagination is accomplished using an offset/size scheme.
       parameters:
-        - name: ids
-          in: query
-          description: The opaque identifiers (e.g. Noids) of the objects to retrieve
-          type: array
-          collectionFormat: csv
-          items:
-            type: string
         - name: q
           in: query
           description: Custom query string for filtering results
           type: string
+          required: true
         - name: offset
           in: query
           type: integer
@@ -322,16 +316,16 @@ definitions:
     properties:
       first:
         type: string
-        description: URL to the first page of the results
+        description: URL to the first page of the results  e.g. '/search?q="search query"'
       previous:
         type: string
-        description: URL to the previous page of the results
+        description: URL to the previous page of the results e.g. '/search?q="search query"?o=400'
       next:
         type: string
-        description: URL to the next page of the results
+        description: URL to the next page of the results e.g. '/search?q="search query"?o=600'
       last:
         type: string
-        description: URL to the last page of the results
+        description: URL to the last page of the results e.g. '/search?q="search query"?o=1200'
   StubObject:
     discriminator: class
     type: object


### PR DESCRIPTION
## Send the thumbnail file itself with appropriate headers

@80251ec7280aedc0b7ee5b1e5932972f8175cd32


## Send file objects as files not binary content

@1593c2fe08e6f567507b64da89721cf4eed11e12


## Further specification of headers for file requests

@3485a0067833c8348108f4dc5adbeabe2a4a862a


## Adding HEAD requests for file objects

@c1d16f22e4ac1e8668f5046044548e6059d842ff


## Refining search interface definition

@b35c68b349344ebc2d40be985c00581b68d5eedb


## Normalizing path names

@5916e7cd3a9c7ea4710a93e80cf11d0ef776d6cb


## Correcting dateTime representation

@75eb05fe594bb5517fd5181f0c74b9b20c6f87dd

To represent a dateTime
type: string
format: date-time

See "Date Types" in http://swagger.io/specification/

## Require API tokens for HEAD requests too

@cc1c2c2d8459c6765cb136a7a3a622a6c45928f9


## Adding missing trailing quotes

@f4f8b12bc41790cf7b259a79c23d8bd6d7d030ca

